### PR TITLE
make GetFirstNetworkInterface() select first nic that is up

### DIFF
--- a/Funbit.Ets.Telemetry.Server/Helpers/NetworkHelper.cs
+++ b/Funbit.Ets.Telemetry.Server/Helpers/NetworkHelper.cs
@@ -9,7 +9,7 @@ namespace Funbit.Ets.Telemetry.Server.Helpers
     {
         static NetworkInterface GetFirstNetworkInterface()
         {
-            var card = NetworkInterface.GetAllNetworkInterfaces().FirstOrDefault(a => a.OperationalStatus.ToString() != "Down");
+            var card = NetworkInterface.GetAllNetworkInterfaces().FirstOrDefault(a => a.OperationalStatus.ToString() == "Up");
             if (card == null)
                 throw new InvalidOperationException("System does not have any registered network interfaces.");
             return card;

--- a/Funbit.Ets.Telemetry.Server/Helpers/NetworkHelper.cs
+++ b/Funbit.Ets.Telemetry.Server/Helpers/NetworkHelper.cs
@@ -9,7 +9,7 @@ namespace Funbit.Ets.Telemetry.Server.Helpers
     {
         static NetworkInterface GetFirstNetworkInterface()
         {
-            var card = NetworkInterface.GetAllNetworkInterfaces().FirstOrDefault();
+            var card = NetworkInterface.GetAllNetworkInterfaces().FirstOrDefault(a => a.OperationalStatus.ToString() != "Down");
             if (card == null)
                 throw new InvalidOperationException("System does not have any registered network interfaces.");
             return card;


### PR DESCRIPTION
On systems with more than 1 nic or a tunnel interface, FirstOrDefault() sometimes returns a nic that is down.

This patch should fix that and only select a nic with appropriate status.