### PR TITLE
Allows disabling the auto-scaling feature

### DIFF
--- a/server/Html/index.html
+++ b/server/Html/index.html
@@ -45,7 +45,11 @@
             <td class="skin-desc">
                 <div><strong>Title</strong>: {{=it.title}}</div>
                 <div><strong>Author</strong>: {{=it.author}}</div>
+                {{? it.width === -1 && it.height === -1}}
+                <div><strong>Size</strong>: Dynamic</div>
+                {{??}}
                 <div><strong>Size</strong>: {{=it.width}} x {{=it.height}}</div>
+                {{?}}
             </td>
         </tr>
     </script>

--- a/server/Html/scripts/app.js
+++ b/server/Html/scripts/app.js
@@ -14,11 +14,11 @@
                     });
                 }
                 App.prototype.initializeViewport = function () {
-					// If the skin defines positive dimensions, we honor those.
-					// If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
-					if (this.skinConfig.width < 1 || this.skinConfig.height < 1) {
-						return;
-					}
+                    // If the skin defines positive dimensions, we honor those.
+                    // If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
+                    if (this.skinConfig.width < 1 || this.skinConfig.height < 1) {
+                        return;
+                    }
 
                     var _this = this;
                     var ie = /Trident/.test(navigator.userAgent);
@@ -85,17 +85,17 @@
                         html += '<script src="' + skinJsUrl + '"></script>';
                         $('body').append(html);
 
-						// If the skin defines positive dimensions, we honor those.
-						// If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
-						if (_this.skinConfig.width > 0 && _this.skinConfig.height > 0) {
-							$('.dashboard').css({
-								position: 'absolute',
-								left: '0px',
-								top: '0px',
-								width: _this.skinConfig.width + 'px',
-								height: _this.skinConfig.height + 'px'
-							});
-						}
+                        // If the skin defines positive dimensions, we honor those.
+                        // If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
+                        if (_this.skinConfig.width > 0 && _this.skinConfig.height > 0) {
+                            $('.dashboard').css({
+                                position: 'absolute',
+                                left: '0px',
+                                top: '0px',
+                                width: _this.skinConfig.width + 'px',
+                                height: _this.skinConfig.height + 'px'
+                            });
+                        }
 
                         _this.dashboard = new Funbit.Ets.Telemetry.Dashboard(Telemetry.Configuration.getUrl('/api/ets2/telemetry'), _this.skinConfig);
                     }).fail(function () {

--- a/server/Html/scripts/app.js
+++ b/server/Html/scripts/app.js
@@ -14,6 +14,12 @@
                     });
                 }
                 App.prototype.initializeViewport = function () {
+					// If the skin defines positive dimensions, we honor those.
+					// If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
+					if (this.skinConfig.width < 1 || this.skinConfig.height < 1) {
+						return;
+					}
+
                     var _this = this;
                     var ie = /Trident/.test(navigator.userAgent);
                     var firefox = /Firefox/i.test(navigator.userAgent);
@@ -78,13 +84,19 @@
                         html += '<script src="' + signalrUrl + '"></script>';
                         html += '<script src="' + skinJsUrl + '"></script>';
                         $('body').append(html);
-                        $('.dashboard').css({
-                            position: 'absolute',
-                            left: '0px',
-                            top: '0px',
-                            width: _this.skinConfig.width + 'px',
-                            height: _this.skinConfig.height + 'px'
-                        });
+
+						// If the skin defines positive dimensions, we honor those.
+						// If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
+						if (_this.skinConfig.width > 0 && _this.skinConfig.height > 0) {
+							$('.dashboard').css({
+								position: 'absolute',
+								left: '0px',
+								top: '0px',
+								width: _this.skinConfig.width + 'px',
+								height: _this.skinConfig.height + 'px'
+							});
+						}
+
                         _this.dashboard = new Funbit.Ets.Telemetry.Dashboard(Telemetry.Configuration.getUrl('/api/ets2/telemetry'), _this.skinConfig);
                     }).fail(function () {
                         alert(Telemetry.Strings.dashboardHtmlLoadFailed + _this.skinConfig.name);

--- a/source/Funbit.Ets.Telemetry.Mobile/scripts/app.js
+++ b/source/Funbit.Ets.Telemetry.Mobile/scripts/app.js
@@ -1,4 +1,4 @@
-﻿var Funbit;
+var Funbit;
 (function (Funbit) {
     (function (Ets) {
         (function (Telemetry) {
@@ -14,6 +14,12 @@
                     });
                 }
                 App.prototype.initializeViewport = function () {
+                    // If the skin defines positive dimensions, we honor those.
+                    // If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
+                    if (this.skinConfig.width < 1 || this.skinConfig.height < 1) {
+                        return;
+                    }
+
                     var _this = this;
                     var ie = /Trident/.test(navigator.userAgent);
                     var firefox = /Firefox/i.test(navigator.userAgent);
@@ -78,13 +84,19 @@
                         html += '<script src="' + signalrUrl + '"></script>';
                         html += '<script src="' + skinJsUrl + '"></script>';
                         $('body').append(html);
-                        $('.dashboard').css({
-                            position: 'absolute',
-                            left: '0px',
-                            top: '0px',
-                            width: _this.skinConfig.width + 'px',
-                            height: _this.skinConfig.height + 'px'
-                        });
+
+                        // If the skin defines positive dimensions, we honor those.
+                        // If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
+                        if (_this.skinConfig.width > 0 && _this.skinConfig.height > 0) {
+                            $('.dashboard').css({
+                                position: 'absolute',
+                                left: '0px',
+                                top: '0px',
+                                width: _this.skinConfig.width + 'px',
+                                height: _this.skinConfig.height + 'px'
+                            });
+                        }
+
                         _this.dashboard = new Funbit.Ets.Telemetry.Dashboard(Telemetry.Configuration.getUrl('/api/ets2/telemetry'), _this.skinConfig);
                     }).fail(function () {
                         alert(Telemetry.Strings.dashboardHtmlLoadFailed + _this.skinConfig.name);

--- a/source/Funbit.Ets.Telemetry.Mobile/scripts/app.ts
+++ b/source/Funbit.Ets.Telemetry.Mobile/scripts/app.ts
@@ -10,7 +10,7 @@ module Funbit.Ets.Telemetry {
         private dashboard: Dashboard;
         private anticacheSeed: number = Date.now();
         private resizeTimer: any;
-        
+
         public static instance: App;
 
         constructor() {
@@ -23,11 +23,16 @@ module Funbit.Ets.Telemetry {
         }
 
         private initializeViewport() {
+            // If the skin defines positive dimensions, we honor those.
+            // If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
+            if (this.skinConfig.width < 1 || this.skinConfig.height < 1) {
+                return;
+            }
 
             var ie = /Trident/.test(navigator.userAgent);
             var firefox = /Firefox/i.test(navigator.userAgent);
             var ios = /iPhone|iPad|iPod/i.test(navigator.userAgent);
-            
+
             // fit viewport into the screen
             var dashboardWidth: number = this.skinConfig.width * 1.0;
             var dashboardHeight: number = this.skinConfig.height * 1.0;
@@ -47,12 +52,12 @@ module Funbit.Ets.Telemetry {
             } else {
                 $body.css('-webkit-transform', scale);
             }
-            
+
             // reload page when orientation changes
             $(window).on('orientationchange', () => {
                 window.location.reload();
-            });    
-            
+            });
+
             // setup window size tracking timer (after 1/4 sec delay)
             if (!ios) { // (Safari on iOS goes crazy with resize event, so we disable it)
                 $(window).resize(() => {
@@ -75,9 +80,9 @@ module Funbit.Ets.Telemetry {
                     }, 0);
                 }, 30000);
             }
-            
+
         }
-        
+
         public initializeDashboard() {
             var skinCssUrl = this.config.getSkinResourceUrl(this.skinConfig, 'dashboard.css');
             var skinHtmlUrl = this.config.getSkinResourceUrl(this.skinConfig, 'dashboard.html');
@@ -96,13 +101,18 @@ module Funbit.Ets.Telemetry {
                 html += '<script src="' + signalrUrl + '"></script>';
                 html += '<script src="' + skinJsUrl + '"></script>';
                 $('body').append(html);
-                $('.dashboard').css({
-                    position: 'absolute',
-                    left: '0px',
-                    top: '0px',
-                    width: this.skinConfig.width + 'px',
-                    height: this.skinConfig.height + 'px'
-                });
+
+                // If the skin defines positive dimensions, we honor those.
+                // If the skin defines zero or negative dimensions, it means the skin will handle the viewport by itself.
+                if (this.skinConfig.width > 0 && this.skinConfig.height > 0) {
+                    $('.dashboard').css({
+                        position: 'absolute',
+                        left: '0px',
+                        top: '0px',
+                        width: this.skinConfig.width + 'px',
+                        height: this.skinConfig.height + 'px'
+                    });
+                }
                 this.dashboard = new Funbit.Ets.Telemetry.Dashboard(
                     Configuration.getUrl('/api/ets2/telemetry'), this.skinConfig);
             }).fail(() => {


### PR DESCRIPTION
Some skins (such as _ets2-mobile-route-advisor_) might want to have
total control of the viewport. For such cases, it is desirable to
disable the _auto-viewport-scaling_ and _auto-reload-when-size-changes_.

This commit implements such behavior by having a non-positive width or
height.

I have not changed the files from "source/Funbit*Server/Html", so those
must be also changed after this pull request.

I have not updated the documentation, which is also another step after
this pull request.
