### PR TITLE
Moving `cursor: pointer` from dashboard-host to individual styles

### DIFF
--- a/server/Html/dashboard-host.css
+++ b/server/Html/dashboard-host.css
@@ -1,5 +1,5 @@
-﻿/* 
-    *** DO NOT CHANGE THIS STYLESHEET *** 
+﻿/*
+    *** DO NOT CHANGE THIS STYLESHEET ***
 */
 body {
   background-color: #1d1d1d;

--- a/server/Html/dashboard-host.css
+++ b/server/Html/dashboard-host.css
@@ -2,7 +2,6 @@
     *** DO NOT CHANGE THIS STYLESHEET *** 
 */
 body {
-  cursor: pointer;
   background-color: #1d1d1d;
   width: 100%;
   height: 100%;

--- a/server/Html/skins/default/dashboard.css
+++ b/server/Html/skins/default/dashboard.css
@@ -1,14 +1,14 @@
-/* 
+/*
     CSS naming convention:
 
     - Dashboard core script maps all telemetry data properties to respective class names,
-      so truck's speed will be .truck-speed and current gear is .truck-gear 
+      so truck's speed will be .truck-speed and current gear is .truck-gear
       (see complete reference in Telemetry.md markdown file).
-    - All boolean telemetry properties will have a special ".yes" class added 
+    - All boolean telemetry properties will have a special ".yes" class added
       when the value is true (will be removed if value is false).
-    - When dashboard core script updates DOM it will always add 
-      data-value attribute containing current value, so you 
-      can use it to have custom css selectors based on the actual data 
+    - When dashboard core script updates DOM it will always add
+      data-value attribute containing current value, so you
+      can use it to have custom css selectors based on the actual data
       (for example, this skin uses .truck-gear[data-value="N"] to define
       different style for neutral or reverse gear, see below).
 

--- a/server/Html/skins/default/dashboard.css
+++ b/server/Html/skins/default/dashboard.css
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
     CSS naming convention:
 
     - Dashboard core script maps all telemetry data properties to respective class names,
@@ -15,6 +15,9 @@
     For more information go to home page: https://github.com/Funbit/ets2-telemetry-server
 
 */
+body {
+  cursor: pointer;
+}
 .hidden {
   visibility: hidden;
 }

--- a/server/html/skins/daf-xf/dashboard.css
+++ b/server/html/skins/daf-xf/dashboard.css
@@ -1,4 +1,7 @@
-﻿.hidden {
+body {
+  cursor: pointer;
+}
+.hidden {
   visibility: hidden;
 }
 .visible {

--- a/server/html/skins/default-mph/dashboard.css
+++ b/server/html/skins/default-mph/dashboard.css
@@ -1,4 +1,7 @@
-﻿.hidden {
+body {
+  cursor: pointer;
+}
+.hidden {
   visibility: hidden;
 }
 .visible {

--- a/server/html/skins/man-tgx/dashboard.css
+++ b/server/html/skins/man-tgx/dashboard.css
@@ -1,4 +1,7 @@
-﻿.hidden {
+body {
+  cursor: pointer;
+}
+.hidden {
   visibility: hidden;
 }
 .visible {

--- a/server/html/skins/mercedes-atego/dashboard.css
+++ b/server/html/skins/mercedes-atego/dashboard.css
@@ -1,4 +1,7 @@
-﻿.hidden {
+body {
+  cursor: pointer;
+}
+.hidden {
   visibility: hidden;
 }
 .visible {

--- a/server/html/skins/rd-info/dashboard.css
+++ b/server/html/skins/rd-info/dashboard.css
@@ -4,6 +4,9 @@
 	src: local('DSDIGI'), url('fonts/DSDIGI.woff') format('woff'), url('fonts/DSDIGI.ttf') format('truetype');
 }
 
+body {
+  cursor: pointer;
+}
 .hidden {
   visibility: hidden;
 }

--- a/server/html/skins/rd-info/dashboard.js
+++ b/server/html/skins/rd-info/dashboard.js
@@ -8,34 +8,28 @@
 	// so you may perform any DOM or resource initializations / image preloading here
 
 	utils.preloadImages([
-        
 		'images/bg-off.png', 'images/bg-on.png',
 		'images/airpressure-on.png', 'images/auxlights-off.png',
 		'images/auxlights-on.png', 'images/cruisecontrol-on.png',
 		'images/dashalert-off.png', 'images/highbeam-on.png',
 		'images/parkbrake-on.png', 'images/dashalert-off.png',
 		'images/sidebar01.png', 'images/sidebar02.png',
-		
 	]);
 	
 	// return to menu by a click
     
 	$(document).add('body').on('click', function () {
-        
 		window.history.back();
-    
 	});
-
-}
-
+};
 
 
 Funbit.Ets.Telemetry.Dashboard.prototype.filter = function (data, utils) {
     
 	//
-    // data - telemetry data JSON object
+	// data - telemetry data JSON object
 	// utils - an object containing several utility functions (see skin tutorial for more information)
-    //    
+	//    
 	// This filter is used to change telemetry data     
 	// before it is displayed on the dashboard.    
 	// You may convert km/h to mph, kilograms to tons, etc.  
@@ -53,7 +47,7 @@ Funbit.Ets.Telemetry.Dashboard.prototype.filter = function (data, utils) {
 	//data.truckSpeedMph = data.truckSpeed * 0.621371;
     
 	// convert kg to t
-    data.hasJob = data.trailer.attached;
+	data.hasJob = data.trailer.attached;
 	data.trailer.mass = (data.trailer.mass / 1000.0) + 't';
 
 	//data.jobIncome = '€' + data.jobIncome;
@@ -72,8 +66,8 @@ Funbit.Ets.Telemetry.Dashboard.prototype.filter = function (data, utils) {
 	//data.truck.lightsAuxOn = (data.truck.lightsAuxFrontOn || data.truck.lightsAuxRoofOn);
 	data._airPressureOn = (data.truck.airePressureWarningOn || data.truck.airPressureEmergencyOn);
 	// format odometer data as: 00000.0
-    //data.truckOdometer = utils.formatFloat(data.truckOdometer, 1);
-    // convert gear to readable format
+	//data.truckOdometer = utils.formatFloat(data.truckOdometer, 1);
+	// convert gear to readable format
     
 	data.truck.gear = data.truck.gear > 0 ? data.truck.gear : (data.truck.gear < 0 ? 'R' : 'N');
 	data.truck.displayedGear = data.truck.displayedGear > 0 ? data.truck.displayedGear : (data.truck.displayedGear < 0 ? 'R' + Math.abs(data.truck.displayedGear) : 'N');
@@ -81,16 +75,14 @@ Funbit.Ets.Telemetry.Dashboard.prototype.filter = function (data, utils) {
 	data._dangerWarning = (data.truck.blinkerLeftOn && data.truck.blinkerRightOn);
 	data._auxLights = (data.truck.lightsAuxRoofOn || data.truck.lightsAuxFronOn);
 	// convert rpm to rpm * 100
-    data.color = (utils.formatFloat(data.truck.speed ,0) > data.navigation.speedLimit) ? '#FFFFFF' : '#FF0000';
+	data.color = (utils.formatFloat(data.truck.speed ,0) > data.navigation.speedLimit) ? '#FFFFFF' : '#FF0000';
 	//data.engineRpm = data.engineRpm / 100;
 
 	data.trailer.wear = Math.round(data.trailer.wear * 100) + '%'; 
 	// return changed data to the core for rendering
     
 	return data;
-
 };
-
 
 
 Funbit.Ets.Telemetry.Dashboard.prototype.render = function (data, utils) {
@@ -101,18 +93,13 @@ Funbit.Ets.Telemetry.Dashboard.prototype.render = function (data, utils) {
 	$('._gameBrakeBar').width(data.truck.gameBrake * 606);
 	$('.navigation-speedLimit').css('color', data.color);
 	//
-    if (data.truck.model === 'New Actros') {
-		$('.truck-make').css('font-size', '75px')
-	};
+	if (data.truck.model === 'New Actros') {
+		$('.truck-make').css('font-size', '75px');
+	}
 	// data - same data object as in the filter function
-    
 	// utils - an object containing several utility functions (see skin tutorial for more information)
-    
 	//
-
     
 	// we don't have anything custom to render in this skin,
-    
 	// but you may use jQuery here to update DOM or CSS
-
-}
+};

--- a/server/html/skins/scania/dashboard.css
+++ b/server/html/skins/scania/dashboard.css
@@ -1,4 +1,7 @@
-﻿.hidden {
+body {
+  cursor: pointer;
+}
+.hidden {
   visibility: hidden;
 }
 .visible {

--- a/server/html/skins/template/dashboard.css
+++ b/server/html/skins/template/dashboard.css
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
     Dashboard skin template.
 
     If you want to create your own dashboard skin (or tweak something)
@@ -22,6 +22,10 @@
     For more information go to home page: https://github.com/Funbit/ets2-telemetry-server
 
 */
+
+body {
+  cursor: pointer;
+}
 
 .dashboard {
 	background-image: url("images/bg-off.jpg");

--- a/server/html/skins/template/dashboard.css
+++ b/server/html/skins/template/dashboard.css
@@ -1,21 +1,21 @@
-/* 
+/*
     Dashboard skin template.
 
     If you want to create your own dashboard skin (or tweak something)
     create a copy of the "/skins/template" directory and rename it
     to something like: "/skins/your_skin_name" and edit config.json file inside.
-    
+
     See skin tutorial PDF file for more information.
 
     CSS naming convention:
 
     - Dashboard core script maps all telemetry data properties to respective class names,
       so truck's speed will be .truck-speed and current gear is .truck-gear (see JSON).
-    - All boolean telemetry properties will have a special ".yes" class added 
+    - All boolean telemetry properties will have a special ".yes" class added
       when the value is true (will be removed if value is false).
-    - When dashboard core script updates DOM it will always add 
-      data-value attribute containing current value, so you 
-      can use it to have custom css selectors based on the actual data 
+    - When dashboard core script updates DOM it will always add
+      data-value attribute containing current value, so you
+      can use it to have custom css selectors based on the actual data
       (for example, this skin uses .truck-gear[data-value="N"] to define
       different style for neutral or reverse gear, see below).
 

--- a/server/html/skins/volvo-fh/dashboard.css
+++ b/server/html/skins/volvo-fh/dashboard.css
@@ -1,4 +1,7 @@
-﻿.hidden {
+body {
+  cursor: pointer;
+}
+.hidden {
   visibility: hidden;
 }
 .visible {

--- a/source/Funbit.Ets.Telemetry.Mobile/dashboard-host.css
+++ b/source/Funbit.Ets.Telemetry.Mobile/dashboard-host.css
@@ -1,8 +1,7 @@
-﻿/* 
-    *** DO NOT CHANGE THIS STYLESHEET *** 
+﻿/*
+    *** DO NOT CHANGE THIS STYLESHEET ***
 */
 body {
-  cursor: pointer;
   background-color: #1d1d1d;
   width: 100%;
   height: 100%;

--- a/source/Funbit.Ets.Telemetry.Mobile/skins/default/dashboard.css
+++ b/source/Funbit.Ets.Telemetry.Mobile/skins/default/dashboard.css
@@ -1,20 +1,23 @@
-﻿/* 
+﻿/*
     CSS naming convention:
 
     - Dashboard core script maps all telemetry data properties to respective class names,
-      so truck's speed will be .truck-speed and current gear is .truck-gear 
+      so truck's speed will be .truck-speed and current gear is .truck-gear
       (see complete reference in Telemetry.md markdown file).
-    - All boolean telemetry properties will have a special ".yes" class added 
+    - All boolean telemetry properties will have a special ".yes" class added
       when the value is true (will be removed if value is false).
-    - When dashboard core script updates DOM it will always add 
-      data-value attribute containing current value, so you 
-      can use it to have custom css selectors based on the actual data 
+    - When dashboard core script updates DOM it will always add
+      data-value attribute containing current value, so you
+      can use it to have custom css selectors based on the actual data
       (for example, this skin uses .truck-gear[data-value="N"] to define
       different style for neutral or reverse gear, see below).
 
     For more information go to home page: https://github.com/Funbit/ets2-telemetry-server
 
 */
+body {
+  cursor: pointer;
+}
 .hidden {
   visibility: hidden;
 }

--- a/source/Funbit.Ets.Telemetry.Mobile/skins/template/dashboard.css
+++ b/source/Funbit.Ets.Telemetry.Mobile/skins/template/dashboard.css
@@ -1,27 +1,31 @@
-﻿/* 
+﻿/*
     Dashboard skin template.
 
     If you want to create your own dashboard skin (or tweak something)
     create a copy of the "/skins/template" directory and rename it
     to something like: "/skins/your_skin_name" and edit config.json file inside.
-    
+
     See skin tutorial PDF file for more information.
 
     CSS naming convention:
 
     - Dashboard core script maps all telemetry data properties to respective class names,
       so truck's speed will be .truck-speed and current gear is .truck-gear (see JSON).
-    - All boolean telemetry properties will have a special ".yes" class added 
+    - All boolean telemetry properties will have a special ".yes" class added
       when the value is true (will be removed if value is false).
-    - When dashboard core script updates DOM it will always add 
-      data-value attribute containing current value, so you 
-      can use it to have custom css selectors based on the actual data 
+    - When dashboard core script updates DOM it will always add
+      data-value attribute containing current value, so you
+      can use it to have custom css selectors based on the actual data
       (for example, this skin uses .truck-gear[data-value="N"] to define
       different style for neutral or reverse gear, see below).
 
     For more information go to home page: https://github.com/Funbit/ets2-telemetry-server
 
 */
+
+body {
+  cursor: pointer;
+}
 
 .dashboard {
 	background-image: url("images/bg-off.jpg");


### PR DESCRIPTION
Setting `cursor: pointer` makes sense for skins that also implement a
`click` handler on `body` element.

For skins that do not implement that (such as
*ets2-mobile-route-advisor*) having that style is just something that
needs to be undone.

Since the click handler is implemented individually in each skin, it
makes sense to add this style individually in each skin as well.

I have not changed the files from "source/Funbit*Server/Html", so
those have to be changed after this pull request.

Note: the diff includes a bunch of whitespace.