### PR TITLE
Adding `<meta charset="utf-8">`

### DIFF
--- a/server/Html/dashboard-host.html
+++ b/server/Html/dashboard-host.html
@@ -4,6 +4,7 @@
     *** DO NOT CHANGE THIS HTML FILE ***
 ================================================================-->
 <head>
+    <meta charset="utf-8">
     <title>ETS2 Dashboard</title>
     <link rel="apple-touch-icon" href="images/app-icon.png" />
     <link rel="shortcut icon" href="images/app-icon.png">

--- a/server/Html/dashboard-host.html
+++ b/server/Html/dashboard-host.html
@@ -6,12 +6,12 @@
 <head>
     <meta charset="utf-8">
     <title>ETS2 Dashboard</title>
-    <link rel="apple-touch-icon" href="images/app-icon.png" />
+    <link rel="apple-touch-icon" href="images/app-icon.png">
     <link rel="shortcut icon" href="images/app-icon.png">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge;" />
-    <link rel="stylesheet" href="dashboard-host.css" />
-    <meta id="viewport" name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge;">
+    <link rel="stylesheet" href="dashboard-host.css">
+    <meta id="viewport" name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 </head>

--- a/server/Html/index.html
+++ b/server/Html/index.html
@@ -4,6 +4,7 @@
             *** DO NOT CHANGE THIS HTML FILE ***
 ================================================================-->
 <head>
+    <meta charset="utf-8">
     <title>ETS2 Dashboard Menu</title>
     <link rel="apple-touch-icon" href="images/app-icon.png" />
     <link rel="shortcut icon" href="images/app-icon.png">

--- a/server/Html/index.html
+++ b/server/Html/index.html
@@ -6,23 +6,23 @@
 <head>
     <meta charset="utf-8">
     <title>ETS2 Dashboard Menu</title>
-    <link rel="apple-touch-icon" href="images/app-icon.png" />
+    <link rel="apple-touch-icon" href="images/app-icon.png">
     <link rel="shortcut icon" href="images/app-icon.png">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge;" />
-    <link rel="stylesheet" href="index.css" />
-    <meta id="viewport" name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge;">
+    <link rel="stylesheet" href="index.css">
+    <meta id="viewport" name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 </head>
 <body>
-    <header><h1><img class="app-icon" src="images/app-icon.png" /> ETS2 Mobile Dashboard</h1></header>
+    <header><h1><img class="app-icon" src="images/app-icon.png"> ETS2 Mobile Dashboard</h1></header>
     <table class="settings">
         <tr>
             <th>Server IP:</th>
             <td>
                 <span class="server-ip"></span>
-                <input class="edit-server-ip" type="button" value="Edit"/>
+                <input class="edit-server-ip" type="button" value="Edit">
             </td>
         </tr>
         <tr>
@@ -32,16 +32,16 @@
     </table>
     <h2>Select a skin to start</h2>
     <table class="skins"></table>
-    <footer>Version 3.0.7<br/>Copyright © 2015, All Rights Reserved</footer>
+    <footer>Version 3.0.7<br>Copyright © 2015, All Rights Reserved</footer>
     <script id="skin-empty-row-template" type="text/html">
         <tr>
-            <td class="skin-empty">Not available.<br/>Please connect to the server first.</td>
+            <td class="skin-empty">Not available.<br>Please connect to the server first.</td>
         </tr>
     </script>
     <script id="skin-row-template" type="text/html">
         <tr data-name="{{=it.name}}">
             <td class="skin-image">
-                <img src="{{=it.splashUrl}}" />
+                <img src="{{=it.splashUrl}}">
             </td>
             <td class="skin-desc">
                 <div><strong>Title</strong>: {{=it.title}}</div>

--- a/source/Funbit.Ets.Telemetry.Mobile/dashboard-host.html
+++ b/source/Funbit.Ets.Telemetry.Mobile/dashboard-host.html
@@ -4,6 +4,7 @@
     *** DO NOT CHANGE THIS HTML FILE ***
 ================================================================-->
 <head>
+    <meta charset="utf-8">
     <title>ETS2 Dashboard</title>
     <link rel="apple-touch-icon" href="images/app-icon.png" />
     <link rel="shortcut icon" href="images/app-icon.png">

--- a/source/Funbit.Ets.Telemetry.Mobile/dashboard-host.html
+++ b/source/Funbit.Ets.Telemetry.Mobile/dashboard-host.html
@@ -6,12 +6,12 @@
 <head>
     <meta charset="utf-8">
     <title>ETS2 Dashboard</title>
-    <link rel="apple-touch-icon" href="images/app-icon.png" />
+    <link rel="apple-touch-icon" href="images/app-icon.png">
     <link rel="shortcut icon" href="images/app-icon.png">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge;" />
-    <link rel="stylesheet" href="dashboard-host.css" />
-    <meta id="viewport" name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge;">
+    <link rel="stylesheet" href="dashboard-host.css">
+    <meta id="viewport" name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 </head>

--- a/source/Funbit.Ets.Telemetry.Mobile/index.html
+++ b/source/Funbit.Ets.Telemetry.Mobile/index.html
@@ -4,6 +4,7 @@
             *** DO NOT CHANGE THIS HTML FILE ***
 ================================================================-->
 <head>
+    <meta charset="utf-8">
     <title>ETS2 Dashboard Menu</title>
     <link rel="apple-touch-icon" href="images/app-icon.png" />
     <link rel="shortcut icon" href="images/app-icon.png">

--- a/source/Funbit.Ets.Telemetry.Mobile/index.html
+++ b/source/Funbit.Ets.Telemetry.Mobile/index.html
@@ -6,23 +6,23 @@
 <head>
     <meta charset="utf-8">
     <title>ETS2 Dashboard Menu</title>
-    <link rel="apple-touch-icon" href="images/app-icon.png" />
+    <link rel="apple-touch-icon" href="images/app-icon.png">
     <link rel="shortcut icon" href="images/app-icon.png">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge;" />
-    <link rel="stylesheet" href="index.css" />
-    <meta id="viewport" name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge;">
+    <link rel="stylesheet" href="index.css">
+    <meta id="viewport" name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 </head>
 <body>
-    <header><h1><img class="app-icon" src="images/app-icon.png" /> ETS2 Mobile Dashboard</h1></header>
+    <header><h1><img class="app-icon" src="images/app-icon.png"> ETS2 Mobile Dashboard</h1></header>
     <table class="settings">
         <tr>
             <th>Server IP:</th>
             <td>
                 <span class="server-ip"></span>
-                <input class="edit-server-ip" type="button" value="Edit"/>
+                <input class="edit-server-ip" type="button" value="Edit">
             </td>
         </tr>
         <tr>
@@ -32,16 +32,16 @@
     </table>
     <h2>Select a skin to start</h2>
     <table class="skins"></table>
-    <footer>Version 3.0.7<br/>Copyright © 2015, All Rights Reserved</footer>
+    <footer>Version 3.0.7<br>Copyright © 2015, All Rights Reserved</footer>
     <script id="skin-empty-row-template" type="text/html">
         <tr>
-            <td class="skin-empty">Not available.<br/>Please connect to the server first.</td>
+            <td class="skin-empty">Not available.<br>Please connect to the server first.</td>
         </tr>
     </script>
     <script id="skin-row-template" type="text/html">
         <tr data-name="{{=it.name}}">
             <td class="skin-image">
-                <img src="{{=it.splashUrl}}" />
+                <img src="{{=it.splashUrl}}">
             </td>
             <td class="skin-desc">
                 <div><strong>Title</strong>: {{=it.title}}</div>


### PR DESCRIPTION
Two changes in this pull request:

* Adding `<meta charset="utf-8">` as early as possible in the HTML files (i.e., right after `<head>`). Should prevent encoding problems.
* Changing `/>` to `>`, just because we are using HTML (and not XML), and those markers are unneeded. Also because some tags had them and others didn't, so now it is more uniform.